### PR TITLE
Lessen errors

### DIFF
--- a/src/ninglex.lisp
+++ b/src/ninglex.lisp
@@ -90,8 +90,11 @@ Param-list should be list of (symbol param-name-as-string).
   (setf (ningle:route *app* route :method method)
         function))
 
-(defparameter *catch-errors* t)
-(defparameter *show-errors* nil)
+(defparameter *catch-errors* t
+  "When t, handle top level errors inside `with-route', but responding with a 500 error.")
+  
+(defparameter *show-errors* nil
+  "When t and `*catch-errors*' is t, send the condition in the response body.")
 
 (defmacro with-route ((route-string params-var &key (method :GET)) &body body)
   "When calling the route, execute the body, binding the params to params-var"

--- a/src/ninglex.lisp
+++ b/src/ninglex.lisp
@@ -35,11 +35,7 @@
   (declare (type (or symbol string) name)
            (type list param-list))
   "Obtain the value of a request parameter called 'name' (string)"
-  (let ((cons-cell (assoc name param-list :test 'equal)))
-     (if cons-cell
-         (cdr cons-cell)
-         ;; else
-         (error (format nil "Request parameter not found: ~a" name)))))
+  (cdr (assoc name param-list :test 'equal)))
 
 (defmacro with-request-params (params-variable param-list &body body)
   (declare (type list param-list) (type symbol params-variable))


### PR DESCRIPTION
`with-route` will turn top level errors into 500 responses. This is customizable with `*catch-errors*` and `*show-errors*`.

`get-param-value` and by extension `with-request-params` will now return `nil` instead of signaling an error. 